### PR TITLE
Made SerialConnection.FromRadio respect readTimeoutMs

### DIFF
--- a/Meshtastic/Connections/SerialConnection.cs
+++ b/Meshtastic/Connections/SerialConnection.cs
@@ -2,6 +2,7 @@ using Google.Protobuf;
 using Meshtastic.Data;
 using Meshtastic.Protobufs;
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using System.IO.Ports;
 
 namespace Meshtastic.Connections;
@@ -93,7 +94,9 @@ public class SerialConnection : DeviceConnection
 
     public override async Task ReadFromRadio(Func<FromRadio, DeviceStateContainer, Task<bool>> isComplete, int readTimeoutMs = Resources.DEFAULT_READ_TIMEOUT)
     {
-        while (serialPort.IsOpen)
+        var sw = new Stopwatch();
+
+        while (serialPort.IsOpen && sw.ElapsedMilliseconds < readTimeoutMs)
         {
             if (serialPort.BytesToRead == 0)
             {


### PR DESCRIPTION
SerialConnection currently does not respect the timeout, which causes issues when trying to write an application that can both read and write to the radio (since it will currently read until it gets a message).