### PR TITLE
Update to latest System.Text.Json

### DIFF
--- a/Meshtastic.Cli/Meshtastic.Cli.csproj
+++ b/Meshtastic.Cli/Meshtastic.Cli.csproj
@@ -36,16 +36,15 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.25.3" />
     <PackageReference Include="Google.Protobuf.Tools" Version="3.25.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
     <PackageReference Include="MQTTnet" Version="4.3.3.952" />
     <PackageReference Include="QRCoder" Version="1.4.3" />
     <PackageReference Include="SimpleExec" Version="12.0.0" />
     <PackageReference Include="Spectre.Console" Version="0.48.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
     <PackageReference Include="System.IO.Ports" Version="8.0.0" />
     <PackageReference Include="YamlDotNet" Version="15.1.2" />
   </ItemGroup>

--- a/Meshtastic/Meshtastic.csproj
+++ b/Meshtastic/Meshtastic.csproj
@@ -33,10 +33,10 @@
 	<ItemGroup>
 		<PackageReference Include="Google.Protobuf" Version="3.25.3" />
 		<PackageReference Include="Google.Protobuf.Tools" Version="3.25.3" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
 		<PackageReference Include="System.IO.Ports" Version="8.0.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
Fix for #94 

Updates Microsoft.Extensions.* to 8.0.1 (pulls System.Text.Json 8.0.5)
Removes System.CommandLine.Hosting (was attempting to pull in 6.0.0) as it is unused + not actively updated - solution builds and no new tests failing