### PR TITLE
Update CI & Docs to Reference .net 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
 
     - name: Restore dependencies
       run: dotnet restore
@@ -37,7 +37,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
 
     - name: Run device simulator
       run: docker run --rm --name device-simulator -d -p 4403:4403 meshtastic/device-simulator
@@ -71,7 +71,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
 
     - name: Setup Python
       uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Vercel](https://img.shields.io/static/v1?label=Powered%20by&message=Vercel&style=flat&logo=vercel&color=000000)](https://vercel.com?utm_source=meshtastic&utm_campaign=oss)
 
 ## Overview
-A cross-platform C# / .NET 7 based command line interface for meshtastic.
+A cross-platform C# / .NET 8 based command line interface for Meshtastic.
 
 
 
@@ -117,7 +117,7 @@ Commands:
 
 ## Installation (dotnet cli / tool method)
 
-* Install the latest [dotnet 7 sdk](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) for your platform 
+* Install the latest [dotnet 8 sdk](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) for your platform 
 * Install the Meshtastic.Cli nuget package as a dotnet tool via `dotnet tool install --global Meshtastic.Cli` in your terminal of choice
 
 ## Installation (standalone executable)


### PR DESCRIPTION
- Switch CI references from .net 7 to .net 8
- Update docs/ links to reference .net 8