### PR TITLE
Updated YamlDotNet to latest version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,6 @@
     <PackageVersion Include="Spectre.Console.Json" Version="0.49.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.IO.Ports" Version="9.0.1" />
-    <PackageVersion Include="YamlDotNet" Version="15.3.0" />
+    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 </Project>

--- a/Meshtastic.Cli/Serialization/FilteredTypeInspector.cs
+++ b/Meshtastic.Cli/Serialization/FilteredTypeInspector.cs
@@ -13,6 +13,10 @@ public class FilteredTypeInspector : TypeInspectorSkeleton
         this.inner = inner;
     }
 
+    public override string GetEnumName(Type enumType, string name) => inner.GetEnumName(enumType, name);
+
+    public override string GetEnumValue(object enumValue) => inner.GetEnumValue(enumValue);
+
     public override IEnumerable<IPropertyDescriptor> GetProperties(Type type, object? container)
     {
         var properties = inner.GetProperties(type, container)


### PR DESCRIPTION
Figured out how to update YamDotNet to the latest version without compiler errors. Needed a change in code which Is used in the export command. Tests run and compares export before and after the update. Results are the same.