### PR TITLE
Add PKI Crypto handling

### DIFF
--- a/Meshtastic.Test/Crypto/PKIEncryptionTests.cs
+++ b/Meshtastic.Test/Crypto/PKIEncryptionTests.cs
@@ -1,0 +1,66 @@
+﻿using System.Text;
+using Google.Protobuf;
+using Meshtastic.Crypto;
+using Meshtastic.Protobufs;
+
+namespace Meshtastic.Test.Crypto;
+public class PKIEncryptionTests
+{
+	[SetUp]
+	public void Setup()
+	{
+	}
+
+	[Test]
+	public void TestRealLifeDecryption()
+	{
+		var rawCapturedPacket = Convert.FromBase64String("DeBEYa4VoIfKoCo0hEfVe6AMHor2d8ciyda+ChJe/DROOMIPWyX8jL56DB3+6127ZQ4HQTGsfQPoS8Rl70e6ZjX2mbLXPeRBd2hFAABIwUgGUAFghP//////////AXgHiAEB");
+		var recipientPrivateKey = Convert.FromBase64String("0FJd8sVxuyr3ee+n8ZVVxozvUbzGORwazxeR8D1iqmg=");
+		var senderPublicKey = Convert.FromBase64String("WWb1Pvgu6zs1dnncqtMcLW6AvFo84U9pJfJp417i+T4=");
+		var meshPacket = MeshPacket.Parser.ParseFrom(rawCapturedPacket);
+
+		meshPacket.Decoded.Should().BeNull();
+		meshPacket.Encrypted.Should().NotBeNull();
+		PKIEncryption.Decrypt(recipientPrivateKey, senderPublicKey, meshPacket);
+		meshPacket.Decoded.Should().NotBeNull();
+		meshPacket.Encrypted.Should().BeNullOrEmpty();
+
+		var plaintext = Encoding.UTF8.GetString(meshPacket.Decoded.Payload.ToArray());
+		plaintext.Should().Be("Test packet for PKI, please ignore");
+	}
+
+	[Test]
+	public void EncryptDecryptRoundTrip()
+	{
+		var plaintext = "Test packet for PKI, please ignore";
+		var recipientKeyPair = PKIEncryption.GenerateKeyPair();
+		var senderKeyPair = PKIEncryption.GenerateKeyPair();
+		var senderMeshPacket = new MeshPacket
+		{
+			From = 2242185114,
+			Id = 1099381122,
+			Decoded = new Protobufs.Data
+			{
+				Payload = ByteString.CopyFrom(Encoding.UTF8.GetBytes(plaintext))
+			}
+		};
+
+		senderMeshPacket.Decoded.Should().NotBeNull();
+		senderMeshPacket.Encrypted.Should().BeNullOrEmpty();
+		PKIEncryption.Encrypt(senderKeyPair.privateKey, recipientKeyPair.publicKey, senderMeshPacket);
+		senderMeshPacket.Decoded.Should().BeNull();
+		senderMeshPacket.Encrypted.Should().NotBeNull();
+
+		var recipientMeshPacket = MeshPacket.Parser.ParseFrom(senderMeshPacket.ToByteArray());
+
+		recipientMeshPacket.Decoded.Should().BeNull();
+		recipientMeshPacket.Encrypted.Should().NotBeNull();
+		PKIEncryption.Decrypt(recipientKeyPair.privateKey, senderKeyPair.publicKey, recipientMeshPacket);
+		recipientMeshPacket.Decoded.Should().NotBeNull();
+		recipientMeshPacket.Encrypted.Should().BeNullOrEmpty();
+
+		recipientMeshPacket.From.Should().Be(senderMeshPacket.From);
+		recipientMeshPacket.Id.Should().Be(senderMeshPacket.Id);
+		Encoding.UTF8.GetString(recipientMeshPacket.Decoded.Payload.ToByteArray()).Should().Be(plaintext);
+	}
+}

--- a/Meshtastic/Crypto/PKIEncryption.cs
+++ b/Meshtastic/Crypto/PKIEncryption.cs
@@ -1,0 +1,98 @@
+﻿using System.Security.Cryptography;
+using Google.Protobuf;
+using Meshtastic.Protobufs;
+using Org.BouncyCastle.Crypto.Modes;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Security;
+
+namespace Meshtastic.Crypto;
+
+public static class PKIEncryption
+{
+	public static (byte[] privateKey, byte[] publicKey) GenerateKeyPair()
+	{
+		var privateKey = GeneratePrivateKey();
+		return (privateKey, GetPublicKeyFromPrivateKey(privateKey));
+	}
+
+	public static byte[] GeneratePrivateKey() => new X25519PrivateKeyParameters(new SecureRandom()).GetEncoded();
+	public static byte[] GetPublicKeyFromPrivateKey(byte[] privateKey) => LoadPrivateKey(privateKey).GeneratePublicKey().GetEncoded();
+
+	private static X25519PrivateKeyParameters LoadPrivateKey(byte[] privateKey) => new X25519PrivateKeyParameters(privateKey, 0);
+	private static X25519PublicKeyParameters LoadPublicKey(byte[] publicKey) => new X25519PublicKeyParameters(publicKey, 0);
+
+	private static byte[] GenerateNonce(uint packetId, uint senderNodeId, uint extraNonce)
+		=> [
+			..BitConverter.GetBytes(packetId),
+			..BitConverter.GetBytes(extraNonce),
+			..BitConverter.GetBytes(senderNodeId),
+			0
+		];
+
+	public static void Decrypt(byte[] recipientPrivateKey, byte[] senderPublicKey, MeshPacket meshPacket)
+	{
+		if (meshPacket.Encrypted == null || meshPacket.Encrypted.Length == 0) return;
+		var encryptedData = meshPacket.Encrypted.ToByteArray();
+		var decrypted = Decrypt(recipientPrivateKey, senderPublicKey, encryptedData, meshPacket.Id, meshPacket.From);
+		var data = Protobufs.Data.Parser.ParseFrom(decrypted);
+		meshPacket.Decoded = data;
+	}
+
+	public static byte[] Decrypt(byte[] recipientPrivateKey, byte[] senderPublicKey, byte[] encryptedData, uint packetId, uint senderNodeId)
+		=> Decrypt(LoadPrivateKey(recipientPrivateKey), LoadPublicKey(senderPublicKey), encryptedData, packetId, senderNodeId);
+
+	private static byte[] GenerateSharedKey(X25519PrivateKeyParameters privateKey, X25519PublicKeyParameters publicKey)
+	{
+		var sharedKey = new byte[32];
+		privateKey.GenerateSecret(publicKey, sharedKey);
+		var hashedSharedKey = SHA256.HashData(sharedKey);
+		return hashedSharedKey;
+	}
+
+	private static byte[] Decrypt(X25519PrivateKeyParameters recipientPrivateKey, X25519PublicKeyParameters senderPublicKey, byte[] encryptedData, uint packetId, uint senderNodeId)
+	{
+		var sharedKey = GenerateSharedKey(recipientPrivateKey, senderPublicKey);
+		var extraNonce = BitConverter.ToUInt32(encryptedData, encryptedData.Length - 4);
+		var nonce = GenerateNonce(packetId, senderNodeId, extraNonce);
+
+		var cipher = new CcmBlockCipher(new Org.BouncyCastle.Crypto.Engines.AesEngine());
+		var parameters = new AeadParameters(new KeyParameter(sharedKey), 64, nonce);
+		cipher.Init(false, parameters);
+
+		byte[] output = new byte[cipher.GetOutputSize(encryptedData.Length - 4)];
+		int len = cipher.ProcessBytes(encryptedData, 0, encryptedData.Length - 4, output, 0);
+		cipher.DoFinal(output, len);
+		return output;
+	}
+
+	public static void Encrypt(byte[] senderPrivateKey, byte[] recipientPublicKey, MeshPacket meshPacket)
+	{
+		if (meshPacket.Encrypted != null && meshPacket.Encrypted.Length > 0) return;
+		if (meshPacket.Decoded == null) return;
+		var plaintext = meshPacket.Decoded.ToByteArray();
+		var encrypted = Encrypt(senderPrivateKey, recipientPublicKey, plaintext, meshPacket.Id, meshPacket.From);
+		meshPacket.Encrypted = ByteString.CopyFrom(encrypted);
+	}
+
+	public static byte[] Encrypt(byte[] senderPrivateKey, byte[] recipientPublicKey, byte[] plaintext, uint packetId, uint senderNodeId)
+		=> Encrypt(LoadPrivateKey(senderPrivateKey), LoadPublicKey(recipientPublicKey), plaintext, packetId, senderNodeId);
+	
+	private static byte[] Encrypt(X25519PrivateKeyParameters senderPrivateKey, X25519PublicKeyParameters recipientPublicKey, byte[] plaintext, uint packetId, uint senderNodeId)
+	{
+		var extraNonce = (uint)new SecureRandom().Next();
+		var sharedKey = GenerateSharedKey(senderPrivateKey, recipientPublicKey);
+		var nonce = GenerateNonce(packetId, senderNodeId, extraNonce);
+
+		var cipher = new CcmBlockCipher(new Org.BouncyCastle.Crypto.Engines.AesEngine());
+		var parameters = new AeadParameters(new KeyParameter(sharedKey), 64, nonce);
+
+		cipher.Init(true, parameters);
+
+		byte[] output = new byte[cipher.GetOutputSize(plaintext.Length) + 4];
+		int len = cipher.ProcessBytes(plaintext, 0, plaintext.Length, output, 0);
+		cipher.DoFinal(output, len);
+		var extraNonceBytes = BitConverter.GetBytes(extraNonce);
+		Array.Copy(extraNonceBytes, 0, output, output.Length - 4, 4);
+		return output;
+	}
+}


### PR DESCRIPTION
This PR adds methods for encrypting and decrypting payloads using PKI. Included are helper methods for generating new keypairs and processing whole `MeshPacket`s. Test cases include decoding a packet captured from real life radio and round-trip of generating two key pair, encrypting, sending and decrypting a packet.