### PR TITLE
Multitarget both .NET 8 and .NET 9 (#120)

### DIFF
--- a/Meshtastic/Meshtastic.csproj
+++ b/Meshtastic/Meshtastic.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Meshtastic</RootNamespace>


### PR DESCRIPTION
With this change, the resulting `.nupkg` targets both .NET 8 and .NET 9 and can be used with either version of the framework.