### PR TITLE
Make XEdDSASigning work with firmware generated signatures

### DIFF
--- a/Meshtastic.Test/Crypto/XEdDSASigningTests.cs
+++ b/Meshtastic.Test/Crypto/XEdDSASigningTests.cs
@@ -51,6 +51,15 @@ public class XEdDSASigningTests
     }
 
     [Test]
+    public void ConvertX25519PublicKeyToEd25519_Should_EqualToGenerateEdDSAKeysFromX25519()
+    {
+        var (x25519PrivateKey, x25519PublicKey) = PKIEncryption.GenerateKeyPair();
+        var (edPrivateKey, edPublicKeyFromPrivate) = XEdDSASigning.GenerateEdDSAKeysFromX25519(x25519PrivateKey);
+        var edPublicKeyFromPublic = XEdDSASigning.ConvertX25519PublicKeyToEd25519(x25519PublicKey);
+        Assert.That(edPublicKeyFromPrivate, Is.EqualTo(edPublicKeyFromPublic));
+    }
+
+    [Test]
     public void Sign_Should_ProduceValidSignature()
     {
         // Arrange

--- a/Meshtastic.Test/Crypto/XEdDSASigningTests.cs
+++ b/Meshtastic.Test/Crypto/XEdDSASigningTests.cs
@@ -58,7 +58,7 @@ public class XEdDSASigningTests
         var (edPrivateKey, edPublicKey) = XEdDSASigning.GenerateEdDSAKeysFromX25519(_testPrivateKey);
 
         // Act
-        var signature = XEdDSASigning.Sign(message, edPrivateKey, edPublicKey, useShortHash: true);
+        var signature = XEdDSASigning.Sign(message, edPrivateKey, edPublicKey);
 
         // Assert
         Assert.That(signature, Is.Not.Null);
@@ -72,10 +72,10 @@ public class XEdDSASigningTests
         // Arrange
         var message = Encoding.UTF8.GetBytes("Test message for verification");
         var (edPrivateKey, edPublicKey) = XEdDSASigning.GenerateEdDSAKeysFromX25519(_testPrivateKey);
-        var signature = XEdDSASigning.Sign(message, edPrivateKey, edPublicKey, useShortHash: true);
+        var signature = XEdDSASigning.Sign(message, edPrivateKey, edPublicKey);
 
         // Act
-        var isValid = XEdDSASigning.Verify(message, signature, edPublicKey, useShortHash: true);
+        var isValid = XEdDSASigning.Verify(message, signature, edPublicKey);
 
         // Assert
         Assert.That(isValid, Is.True);
@@ -90,7 +90,7 @@ public class XEdDSASigningTests
         var (_, edPublicKey) = XEdDSASigning.GenerateEdDSAKeysFromX25519(_testPrivateKey);
 
         // Act
-        var isValid = XEdDSASigning.Verify(message, invalidSignature, edPublicKey, useShortHash: true);
+        var isValid = XEdDSASigning.Verify(message, invalidSignature, edPublicKey);
 
         // Assert
         Assert.That(isValid, Is.False);
@@ -103,29 +103,13 @@ public class XEdDSASigningTests
         var originalMessage = Encoding.UTF8.GetBytes("Original message");
         var tamperedMessage = Encoding.UTF8.GetBytes("Tampered message");
         var (edPrivateKey, edPublicKey) = XEdDSASigning.GenerateEdDSAKeysFromX25519(_testPrivateKey);
-        var signature = XEdDSASigning.Sign(originalMessage, edPrivateKey, edPublicKey, useShortHash: true);
+        var signature = XEdDSASigning.Sign(originalMessage, edPrivateKey, edPublicKey);
 
         // Act
-        var isValid = XEdDSASigning.Verify(tamperedMessage, signature, edPublicKey, useShortHash: true);
+        var isValid = XEdDSASigning.Verify(tamperedMessage, signature, edPublicKey);
 
         // Assert
         Assert.That(isValid, Is.False);
-    }
-
-    [TestCase(true)]
-    [TestCase(false)]
-    public void SignAndVerify_Should_Work_WithBothHashTypes(bool useShortHash)
-    {
-        // Arrange
-        var message = Encoding.UTF8.GetBytes("Test message for both hash types");
-        var (edPrivateKey, edPublicKey) = XEdDSASigning.GenerateEdDSAKeysFromX25519(_testPrivateKey);
-
-        // Act
-        var signature = XEdDSASigning.Sign(message, edPrivateKey, edPublicKey, useShortHash);
-        var isValid = XEdDSASigning.Verify(message, signature, edPublicKey, useShortHash);
-
-        // Assert
-        Assert.That(isValid, Is.True);
     }
 
     [Test]

--- a/Meshtastic.Test/Crypto/XEdDSASigningTests.cs
+++ b/Meshtastic.Test/Crypto/XEdDSASigningTests.cs
@@ -113,6 +113,38 @@ public class XEdDSASigningTests
     }
 
     [Test]
+    public void Verify_RealLife_ValidSignature()
+    {
+        var rawCapturedPacket = Convert.FromBase64String("DbVdZX4V/////xgVIkwIARIEVGVzdEgBUkDdbuxwz2lvDyBKpCW1ojj+pMPfnRfWiUsDwf1cwisx+82L7fA5/g5OW5LrpWfU4z73AHqysNLKBUOt3TfhBEQONXE20CI9ieBNakgHWGR4B5gBtQE=");
+        var senderPublicKey = Convert.FromBase64String("t0hKwMywRb2nKFOvVXcjFAGPWgCSta4ZwEkgPkgJWwM=");
+        var meshPacket = MeshPacket.Parser.ParseFrom(rawCapturedPacket);
+        var isValid = XEdDSASigning.VerifyPacketSignature(senderPublicKey, meshPacket);
+        Assert.That(isValid, Is.True);
+    }
+
+    [Test]
+    public void Verify_RealLife_InvalidPubkey()
+    {
+        var rawCapturedPacket = Convert.FromBase64String("DbVdZX4V/////xgVIkwIARIEVGVzdEgBUkDdbuxwz2lvDyBKpCW1ojj+pMPfnRfWiUsDwf1cwisx+82L7fA5/g5OW5LrpWfU4z73AHqysNLKBUOt3TfhBEQONXE20CI9ieBNakgHWGR4B5gBtQE=");
+        var senderPublicKey = Convert.FromBase64String("t0hKwMywRb2nKFOvVXcjFAGPWgCSta4ZwEkgPkgJWwM=");
+        senderPublicKey[0]++;
+        var meshPacket = MeshPacket.Parser.ParseFrom(rawCapturedPacket);
+        var isValid = XEdDSASigning.VerifyPacketSignature(senderPublicKey, meshPacket);
+        Assert.That(isValid, Is.False);
+    }
+
+    [Test]
+    public void Verify_RealLife_TamperedMessage()
+    {
+        var rawCapturedPacket = Convert.FromBase64String("DbVdZX4V/////xgVIkwIARIEVGVzdEgBUkDdbuxwz2lvDyBKpCW1ojj+pMPfnRfWiUsDwf1cwisx+82L7fA5/g5OW5LrpWfU4z73AHqysNLKBUOt3TfhBEQONXE20CI9ieBNakgHWGR4B5gBtQE=");
+        var senderPublicKey = Convert.FromBase64String("t0hKwMywRb2nKFOvVXcjFAGPWgCSta4ZwEkgPkgJWwM=");
+        var meshPacket = MeshPacket.Parser.ParseFrom(rawCapturedPacket);
+        meshPacket.Decoded.Payload = Google.Protobuf.ByteString.CopyFromUtf8("Tampered");
+        var isValid = XEdDSASigning.VerifyPacketSignature(senderPublicKey, meshPacket);
+        Assert.That(isValid, Is.False);
+    }
+
+    [Test]
     public void Sign_Should_ThrowException_ForNullMessage()
     {
         // Arrange

--- a/Meshtastic.Test/Crypto/XEdDSASigningTests.cs
+++ b/Meshtastic.Test/Crypto/XEdDSASigningTests.cs
@@ -51,11 +51,40 @@ public class XEdDSASigningTests
     }
 
     [Test]
-    public void ConvertX25519PublicKeyToEd25519_Should_EqualToGenerateEdDSAKeysFromX25519()
+    public void ConvertX25519PublicKeyToEd25519_Should_EqualToGenerateEdDSAKeysFromX25519_Positive()
     {
-        var (x25519PrivateKey, x25519PublicKey) = PKIEncryption.GenerateKeyPair();
-        var (edPrivateKey, edPublicKeyFromPrivate) = XEdDSASigning.GenerateEdDSAKeysFromX25519(x25519PrivateKey);
+        byte[] x25519PrivateKey;
+        byte[] x25519PublicKey;
+
+        // Generate X25519 keypairs until one producing positive Ed25519 is found
+        while (true)
+        {
+            (x25519PrivateKey, x25519PublicKey) = PKIEncryption.GenerateKeyPair();
+            var edPublic = XEdDSASigning.ConvertX25519PublicKeyToEd25519(x25519PublicKey, forcePositive: false);
+            if ((edPublic[31] & 0x80) == 0) break;
+        }
+
         var edPublicKeyFromPublic = XEdDSASigning.ConvertX25519PublicKeyToEd25519(x25519PublicKey);
+        var (_, edPublicKeyFromPrivate) = XEdDSASigning.GenerateEdDSAKeysFromX25519(x25519PrivateKey);
+        Assert.That(edPublicKeyFromPrivate, Is.EqualTo(edPublicKeyFromPublic));
+    }
+
+    [Test]
+    public void ConvertX25519PublicKeyToEd25519_Should_EqualToGenerateEdDSAKeysFromX25519_Negative()
+    {
+        byte[] x25519PrivateKey;
+        byte[] x25519PublicKey;
+
+        // Generate X25519 keypairs until one producing negative Ed25519 is found
+        while (true)
+        {
+            (x25519PrivateKey, x25519PublicKey) = PKIEncryption.GenerateKeyPair();
+            var edPublic = XEdDSASigning.ConvertX25519PublicKeyToEd25519(x25519PublicKey, forcePositive: false);
+            if ((edPublic[31] & 0x80) != 0) break;
+        }
+
+        var edPublicKeyFromPublic = XEdDSASigning.ConvertX25519PublicKeyToEd25519(x25519PublicKey);
+        var (_, edPublicKeyFromPrivate) = XEdDSASigning.GenerateEdDSAKeysFromX25519(x25519PrivateKey);
         Assert.That(edPublicKeyFromPrivate, Is.EqualTo(edPublicKeyFromPublic));
     }
 

--- a/Meshtastic.Test/Crypto/XEdDSASigningTests.cs
+++ b/Meshtastic.Test/Crypto/XEdDSASigningTests.cs
@@ -53,17 +53,8 @@ public class XEdDSASigningTests
     [Test]
     public void ConvertX25519PublicKeyToEd25519_Should_EqualToGenerateEdDSAKeysFromX25519_Positive()
     {
-        byte[] x25519PrivateKey;
-        byte[] x25519PublicKey;
-
-        // Generate X25519 keypairs until one producing positive Ed25519 is found
-        while (true)
-        {
-            (x25519PrivateKey, x25519PublicKey) = PKIEncryption.GenerateKeyPair();
-            var edPublic = XEdDSASigning.ConvertX25519PublicKeyToEd25519(x25519PublicKey, forcePositive: false);
-            if ((edPublic[31] & 0x80) == 0) break;
-        }
-
+        var x25519PrivateKey = Convert.FromBase64String("+ATTWKM68dlArUzWrXWlQm45Gi3ZYrOdDt2z5VT5+2o=");
+        var x25519PublicKey = PKIEncryption.GetPublicKeyFromPrivateKey(x25519PrivateKey);
         var edPublicKeyFromPublic = XEdDSASigning.ConvertX25519PublicKeyToEd25519(x25519PublicKey);
         var (_, edPublicKeyFromPrivate) = XEdDSASigning.GenerateEdDSAKeysFromX25519(x25519PrivateKey);
         Assert.That(edPublicKeyFromPrivate, Is.EqualTo(edPublicKeyFromPublic));
@@ -72,17 +63,8 @@ public class XEdDSASigningTests
     [Test]
     public void ConvertX25519PublicKeyToEd25519_Should_EqualToGenerateEdDSAKeysFromX25519_Negative()
     {
-        byte[] x25519PrivateKey;
-        byte[] x25519PublicKey;
-
-        // Generate X25519 keypairs until one producing negative Ed25519 is found
-        while (true)
-        {
-            (x25519PrivateKey, x25519PublicKey) = PKIEncryption.GenerateKeyPair();
-            var edPublic = XEdDSASigning.ConvertX25519PublicKeyToEd25519(x25519PublicKey, forcePositive: false);
-            if ((edPublic[31] & 0x80) != 0) break;
-        }
-
+        var x25519PrivateKey = Convert.FromBase64String("wJNheemu5n2oPgpu0BpEdomsPlChBSM8gAO7RRWkT2w=");
+        var x25519PublicKey = PKIEncryption.GetPublicKeyFromPrivateKey(x25519PrivateKey);
         var edPublicKeyFromPublic = XEdDSASigning.ConvertX25519PublicKeyToEd25519(x25519PublicKey);
         var (_, edPublicKeyFromPrivate) = XEdDSASigning.GenerateEdDSAKeysFromX25519(x25519PrivateKey);
         Assert.That(edPublicKeyFromPrivate, Is.EqualTo(edPublicKeyFromPublic));

--- a/Meshtastic/Crypto/XEdDSASigning.cs
+++ b/Meshtastic/Crypto/XEdDSASigning.cs
@@ -6,6 +6,7 @@ using Org.BouncyCastle.Crypto.Generators;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Math;
 using System.Text;
+using Meshtastic.Protobufs;
 
 namespace Meshtastic.Crypto;
 
@@ -92,6 +93,24 @@ public static class XEdDSASigning
         // Set the sign bit to 0 (positive x)
         edPublicKeyResult[31] &= 0x7F;
         return edPublicKeyResult;
+    }
+
+    private static byte[] BuildSigningBuffer(MeshPacket meshPacket)
+    {
+        return [
+            ..BitConverter.GetBytes(meshPacket.From),
+            ..BitConverter.GetBytes(meshPacket.Id),
+            ..BitConverter.GetBytes((uint)meshPacket.Decoded.Portnum),
+            ..meshPacket.Decoded.Payload.ToByteArray()
+        ];
+    }
+
+    public static bool VerifyPacketSignature(byte[] senderPublicKey, MeshPacket meshPacket)
+    {
+        var message = BuildSigningBuffer(meshPacket);
+        var signature = meshPacket.Decoded.XeddsaSignature.ToByteArray();
+        var edPublicKey = ConvertX25519PublicKeyToEd25519(senderPublicKey);
+        return Verify(message, signature, edPublicKey);
     }
 
     /// <summary>

--- a/Meshtastic/Crypto/XEdDSASigning.cs
+++ b/Meshtastic/Crypto/XEdDSASigning.cs
@@ -41,32 +41,9 @@ public static class XEdDSASigning
         if (x25519PrivateKey.Length != 32)
             throw new ArgumentException("X25519 private key must be 32 bytes", nameof(x25519PrivateKey));
 
-        // For simplicity, use the X25519 key as seed for Ed25519 key generation
-        // In a full XEdDSA implementation, this would use proper key derivation
-        var hashedSeed = SHA256.HashData(x25519PrivateKey);
-        
-        var keyPairGen = new Ed25519KeyPairGenerator();
-        var secureRandom = new SecureRandom();
-        secureRandom.SetSeed(hashedSeed);
-        keyPairGen.Init(new KeyGenerationParameters(secureRandom, 256));
-        
-        var keyPair = keyPairGen.GenerateKeyPair();
-        // Proper XEdDSA key derivation with domain separation
-        // Ed25519 seed = SHA-512("XEdDSA" || x25519PrivateKey)[0..31]
-        byte[] domain = Encoding.ASCII.GetBytes("XEdDSA");
-        byte[] input = new byte[domain.Length + x25519PrivateKey.Length];
-        Buffer.BlockCopy(domain, 0, input, 0, domain.Length);
-        Buffer.BlockCopy(x25519PrivateKey, 0, input, domain.Length, x25519PrivateKey.Length);
-        byte[] hash = SHA512.HashData(input);
-        byte[] ed25519Seed = new byte[32];
-        Array.Copy(hash, 0, ed25519Seed, 0, 32);
-
-        // Create Ed25519 private key from seed
-        var edPrivateKeyParam = new Ed25519PrivateKeyParameters(ed25519Seed, 0);
-        var edPublicKeyParam = edPrivateKeyParam.GeneratePublicKey();
-        var privateKey = edPrivateKeyParam.GetEncoded();
-        var publicKey = edPublicKeyParam.GetEncoded();
-        return (privateKey, publicKey);
+        var x25519PublicKey = PKIEncryption.GetPublicKeyFromPrivateKey(x25519PrivateKey);
+        var ed25519PublicKey = ConvertX25519PublicKeyToEd25519(x25519PublicKey);
+        return (x25519PrivateKey, ed25519PublicKey);
     }
 
     /// <summary>

--- a/Meshtastic/Crypto/XEdDSASigning.cs
+++ b/Meshtastic/Crypto/XEdDSASigning.cs
@@ -113,6 +113,14 @@ public static class XEdDSASigning
         return Verify(message, signature, edPublicKey);
     }
 
+    public static void AddPacketSignature(byte[] senderPrivateKey, MeshPacket meshPacket)
+    {
+        var message = BuildSigningBuffer(meshPacket);
+        var (edPrivateKey, edPublicKey) = GenerateEdDSAKeysFromX25519(senderPrivateKey);
+        var signature = Sign(message, edPrivateKey, edPublicKey);
+        meshPacket.Decoded.XeddsaSignature = Google.Protobuf.ByteString.CopyFrom(signature);
+    }
+
     /// <summary>
     /// Sign a message using Ed25519
     /// </summary>

--- a/Meshtastic/Crypto/XEdDSASigning.cs
+++ b/Meshtastic/Crypto/XEdDSASigning.cs
@@ -32,6 +32,28 @@ public static class XEdDSASigning
         return (privateKey, publicKey);
     }
 
+    private static byte[] GeneratePublicKeyFromPrivateKey(byte[] ed25519PrivateKey)
+    {
+        /*
+         * Normally the public key should be obtained by calling:
+         * new Ed25519PrivateKeyParameters(ed25519PrivateKey).GeneratePublicKey().GetEncoded()
+         * but in firmware's function XEdDSA::priv_curve_to_ed_keys private key is used as-is
+         * as a scalar, while BouncyCastle's GeneratePublicKey first passes private key material
+         * through SHA512 to obtain 64-byte seed, of which 2nd half is used as a scalar and multiplied
+         * by curve's base point to obtain public key.
+         * 
+         * Reimplementing field multiplication, as provided by ScalarMultBaseEncoded, in this project
+         * seems pointless - hence use of reflection to gain access to this primitive to generate
+         * a public key directly from provided material.
+         */
+
+        var ed25519PublicKey = new byte[32];
+        typeof(Org.BouncyCastle.Math.EC.Rfc8032.Ed25519)
+            .GetMethod("ScalarMultBaseEncoded", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static, [typeof(byte[]), typeof(byte[]), typeof(int)])!
+            .Invoke(null, [ed25519PrivateKey, ed25519PublicKey, 0]);
+        return ed25519PublicKey;
+    }
+
     /// <summary>
     /// Generate Ed25519 keys from an X25519 private key (simplified for demo)
     /// </summary>
@@ -44,29 +66,33 @@ public static class XEdDSASigning
 
         var ed25519PrivateKey = new byte[32];
         Array.Copy(x25519PrivateKey, ed25519PrivateKey, ed25519PrivateKey.Length);
+
         // Clamp X25519
         ed25519PrivateKey[0] &= 0xF8;
         ed25519PrivateKey[31] &= 0x7F;
         ed25519PrivateKey[31] |= 0x40;
 
         var x25519PublicKey = PKIEncryption.GetPublicKeyFromPrivateKey(x25519PrivateKey);
-        var ed25519PublicKey = ConvertX25519PublicKeyToEd25519(x25519PublicKey, forcePositive: false);
+        var ed25519PublicKey = GeneratePublicKeyFromPrivateKey(ed25519PrivateKey);
 
         // If resulting public key is positive, return as-is
-        if ((ed25519PublicKey[31] & 0x80) == 0) return (x25519PrivateKey, ed25519PublicKey);
+        if ((ed25519PublicKey[31] & 0x80) == 0) return (ed25519PrivateKey, ed25519PublicKey);
 
         // Ed25519 Group Order
         var L = new BigInteger("7237005577332262213973186563042994240857116359379907606001950938285454250989");
 
         // Negate private key
-        var privateKeyScalar = new BigInteger(ed25519PrivateKey.Reverse().ToArray());
+        var privateKeyScalar = new BigInteger(1, ed25519PrivateKey.Reverse().ToArray());
         var negatedPrivateKeyScalar = L.Subtract(privateKeyScalar);
         var negatedPrivateKeyBytes = negatedPrivateKeyScalar.ToByteArrayUnsigned();
         byte[] negatedPrivateKey = new byte[32];
-        Array.Copy(negatedPrivateKeyBytes, 0, negatedPrivateKey, 0, negatedPrivateKeyBytes.Length);
+        for (int i = 0; i < negatedPrivateKeyBytes.Length && i < 32; i++)
+        {
+            negatedPrivateKey[i] = negatedPrivateKeyBytes[negatedPrivateKeyBytes.Length - 1 - i];
+        }
 
         // Recompute public key from negated privated key
-        var negatedPublicKey = ConvertX25519PublicKeyToEd25519(negatedPrivateKey);
+        var negatedPublicKey = GeneratePublicKeyFromPrivateKey(negatedPrivateKey);
 
         return (negatedPrivateKey, negatedPublicKey);
     }

--- a/Meshtastic/Crypto/XEdDSASigning.cs
+++ b/Meshtastic/Crypto/XEdDSASigning.cs
@@ -8,6 +8,7 @@ using Org.BouncyCastle.Math;
 using System.Text;
 using Meshtastic.Protobufs;
 using Org.BouncyCastle.Math.EC.Rfc8032;
+using Org.BouncyCastle.Crypto.Digests;
 
 namespace Meshtastic.Crypto;
 
@@ -199,8 +200,50 @@ public static class XEdDSASigning
          * Ed25519Signer computes public key from private key differently than firmware (see comment for GeneratePublicKeyFromPrivateKey)
          * and causes signature verification by actual radios to fail, so instead use Ed25519 primitive directly, explicitly passing 
          * public key computed derived as in XEdDSA::priv_curve_to_ed_keys.
+         * 
+         * Also, Ed25519.Sign passes sk (private key) through SHA-512 before feeding it to actual ImplSign, which for some reason
+         * later fails to verify both by firmware and by Ed25519.Verify.
+         * 
+         * The following code is inlined from BouncyCastle's Ed25519 class, method:
+         * private static void ImplSign(byte[] sk, int skOff, byte[] pk, int pkOff, byte[] ctx, byte phflag, byte[] m, int mOff, int mLen, byte[] sig, int sigOff)
          */
-        Ed25519.Sign(edPrivateKey, 0, edPublicKey, 0, null, message, 0, message.Length, signature, 0);
+
+        var digest = new Sha512Digest();
+        var h = new byte[64];
+
+        digest.BlockUpdate(edPrivateKey, 0, 32);
+        digest.DoFinal(h, 0);
+
+        typeof(Ed25519)
+            .GetMethod("ImplSign", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static, 
+            [
+                typeof(IDigest),
+                typeof(byte[]),
+                typeof(byte[]),
+                typeof(byte[]),
+                typeof(int),
+                typeof(byte[]),
+                typeof(byte),
+                typeof(byte[]),
+                typeof(int),
+                typeof(int),
+                typeof(byte[]),
+                typeof(int)
+            ])!
+            .Invoke(null, [
+                /* IDigest d */ digest,
+                /* byte[] h */ h,
+                /* byte[] s */ edPrivateKey /* original argument: s, scalar computed from h */,
+                /* byte[] pk */ edPublicKey,
+                /* int pkOff */ 0,
+                /* byte[] ctx */ null,
+                /* byte phflag */ (byte)0,
+                /* byte[] */ message,
+                /* int mOff*/ 0,
+                /* int mLen */ message.Length,
+                /* byte[] sig */ signature,
+                /* int sigOff */ 0]);
+
         return signature;
     }
 

--- a/Meshtastic/Crypto/XEdDSASigning.cs
+++ b/Meshtastic/Crypto/XEdDSASigning.cs
@@ -129,6 +129,12 @@ public static class XEdDSASigning
         ];
     }
 
+    /// <summary>
+    /// Verify MeshPacket signature using provided node's X25519 public key.
+    /// </summary>
+    /// <param name="senderPublicKey">Public key of sender node.</param>
+    /// <param name="meshPacket">Packet to verify.</param>
+    /// <returns>True is packet signature is valid</returns>
     public static bool VerifyPacketSignature(byte[] senderPublicKey, MeshPacket meshPacket)
     {
         var message = BuildSigningBuffer(meshPacket);
@@ -137,6 +143,11 @@ public static class XEdDSASigning
         return Verify(message, signature, edPublicKey);
     }
 
+    /// <summary>
+    /// Adds a signature to provided MeshPacket.
+    /// </summary>
+    /// <param name="senderPrivateKey">Private X25519 key of packet sender.</param>
+    /// <param name="meshPacket">Packet to sign.</param>
     public static void AddPacketSignature(byte[] senderPrivateKey, MeshPacket meshPacket)
     {
         var message = BuildSigningBuffer(meshPacket);

--- a/Meshtastic/Crypto/XEdDSASigning.cs
+++ b/Meshtastic/Crypto/XEdDSASigning.cs
@@ -113,20 +113,17 @@ public static class XEdDSASigning
     /// <param name="edPrivateKey">Ed25519 private key</param>
     /// <param name="useShortHash">Use SHA-256 instead of SHA-512 for hashing before signing</param>
     /// <returns>64-byte signature</returns>
-    public static byte[] Sign(byte[] message, byte[] edPrivateKey, byte[] edPublicKey, bool useShortHash = true)
+    public static byte[] Sign(byte[] message, byte[] edPrivateKey, byte[] edPublicKey)
     {
         if (message == null) throw new ArgumentNullException(nameof(message));
         if (edPrivateKey.Length != 32) throw new ArgumentException("Ed25519 private key must be 32 bytes", nameof(edPrivateKey));
-
-        // Hash the message using the selected algorithm
-        var messageHash = useShortHash ? SHA256.HashData(message) : SHA512.HashData(message);
 
         // Create Ed25519 signer
         var signer = new Ed25519Signer();
         var privateKeyParams = new Ed25519PrivateKeyParameters(edPrivateKey, 0);
         
         signer.Init(true, privateKeyParams);
-        signer.BlockUpdate(messageHash, 0, messageHash.Length);
+        signer.BlockUpdate(message, 0, message.Length);
         
         return signer.GenerateSignature();
     }
@@ -139,7 +136,7 @@ public static class XEdDSASigning
     /// <param name="edPublicKey">Ed25519 public key of the signer</param>
     /// <param name="useShortHash">Use SHA-256 instead of SHA-512 for hashing</param>
     /// <returns>True if signature is valid</returns>
-    public static bool Verify(byte[] message, byte[] signature, byte[] edPublicKey, bool useShortHash = true)
+    public static bool Verify(byte[] message, byte[] signature, byte[] edPublicKey)
     {
         if (message == null) throw new ArgumentNullException(nameof(message));
         if (signature == null || signature.Length != 64) throw new ArgumentException("Signature must be 64 bytes", nameof(signature));
@@ -147,15 +144,12 @@ public static class XEdDSASigning
 
         try
         {
-            // Hash the message using the selected algorithm
-            var messageHash = useShortHash ? SHA256.HashData(message) : SHA512.HashData(message);
-
             // Create Ed25519 verifier
             var verifier = new Ed25519Signer();
             var publicKeyParams = new Ed25519PublicKeyParameters(edPublicKey, 0);
             
             verifier.Init(false, publicKeyParams);
-            verifier.BlockUpdate(messageHash, 0, messageHash.Length);
+            verifier.BlockUpdate(message, 0, message.Length);
             
             return verifier.VerifySignature(signature);
         }
@@ -173,13 +167,13 @@ public static class XEdDSASigning
     /// <param name="x25519PublicKey">X25519 public key of the signer</param>
     /// <param name="useShortHash">Use SHA-256 instead of SHA-512 for verification</param>
     /// <returns>True if signature is valid</returns>
-    public static bool VerifyWithX25519Key(byte[] message, byte[] signature, byte[] x25519PublicKey, bool useShortHash = true)
+    public static bool VerifyWithX25519Key(byte[] message, byte[] signature, byte[] x25519PublicKey)
     {
         try
         {
             // Convert X25519 public key to Ed25519 public key
             var edPublicKey = ConvertX25519PublicKeyToEd25519(x25519PublicKey);
-            return Verify(message, signature, edPublicKey, useShortHash);
+            return Verify(message, signature, edPublicKey);
         }
         catch
         {

--- a/Meshtastic/Crypto/XEdDSASigning.cs
+++ b/Meshtastic/Crypto/XEdDSASigning.cs
@@ -56,18 +56,6 @@ public static class XEdDSASigning
         if (x25519PublicKey.Length != 32)
             throw new ArgumentException("X25519 public key must be 32 bytes", nameof(x25519PublicKey));
 
-        // Simplified conversion - in practice would use proper birational map
-        // For demo purposes, derive deterministic Ed25519 key from X25519 key
-        var hashedKey = SHA256.HashData(x25519PublicKey);
-        
-        var keyPairGen = new Ed25519KeyPairGenerator();
-        var secureRandom = new SecureRandom();
-        secureRandom.SetSeed(hashedKey);
-        keyPairGen.Init(new KeyGenerationParameters(secureRandom, 256));
-        
-        var keyPair = keyPairGen.GenerateKeyPair();
-        var edPublicKey = ((Ed25519PublicKeyParameters)keyPair.Public).GetEncoded();
-        
         // Clear the sign bit (bit 7 of the last byte) as per Ed25519 specification
         // Implements the birational map from Montgomery (X25519) u to Edwards (Ed25519) y:
         // y = (u - 1) / (u + 1) mod p

--- a/Meshtastic/Crypto/XEdDSASigning.cs
+++ b/Meshtastic/Crypto/XEdDSASigning.cs
@@ -7,6 +7,7 @@ using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Math;
 using System.Text;
 using Meshtastic.Protobufs;
+using Org.BouncyCastle.Math.EC.Rfc8032;
 
 namespace Meshtastic.Crypto;
 
@@ -187,21 +188,20 @@ public static class XEdDSASigning
     /// </summary>
     /// <param name="message">Message to sign</param>
     /// <param name="edPrivateKey">Ed25519 private key</param>
-    /// <param name="useShortHash">Use SHA-256 instead of SHA-512 for hashing before signing</param>
+    /// <param name="edPublicKey">Ed25519 public key</param>
     /// <returns>64-byte signature</returns>
     public static byte[] Sign(byte[] message, byte[] edPrivateKey, byte[] edPublicKey)
     {
         if (message == null) throw new ArgumentNullException(nameof(message));
         if (edPrivateKey.Length != 32) throw new ArgumentException("Ed25519 private key must be 32 bytes", nameof(edPrivateKey));
-
-        // Create Ed25519 signer
-        var signer = new Ed25519Signer();
-        var privateKeyParams = new Ed25519PrivateKeyParameters(edPrivateKey, 0);
-        
-        signer.Init(true, privateKeyParams);
-        signer.BlockUpdate(message, 0, message.Length);
-        
-        return signer.GenerateSignature();
+        var signature = new byte[64];
+        /*
+         * Ed25519Signer computes public key from private key differently than firmware (see comment for GeneratePublicKeyFromPrivateKey)
+         * and causes signature verification by actual radios to fail, so instead use Ed25519 primitive directly, explicitly passing 
+         * public key computed derived as in XEdDSA::priv_curve_to_ed_keys.
+         */
+        Ed25519.Sign(edPrivateKey, 0, edPublicKey, 0, null, message, 0, message.Length, signature, 0);
+        return signature;
     }
 
     /// <summary>
@@ -210,29 +210,13 @@ public static class XEdDSASigning
     /// <param name="message">Original message</param>
     /// <param name="signature">64-byte signature</param>
     /// <param name="edPublicKey">Ed25519 public key of the signer</param>
-    /// <param name="useShortHash">Use SHA-256 instead of SHA-512 for hashing</param>
     /// <returns>True if signature is valid</returns>
     public static bool Verify(byte[] message, byte[] signature, byte[] edPublicKey)
     {
         if (message == null) throw new ArgumentNullException(nameof(message));
         if (signature == null || signature.Length != 64) throw new ArgumentException("Signature must be 64 bytes", nameof(signature));
         if (edPublicKey == null || edPublicKey.Length != 32) throw new ArgumentException("Ed25519 public key must be 32 bytes", nameof(edPublicKey));
-
-        try
-        {
-            // Create Ed25519 verifier
-            var verifier = new Ed25519Signer();
-            var publicKeyParams = new Ed25519PublicKeyParameters(edPublicKey, 0);
-            
-            verifier.Init(false, publicKeyParams);
-            verifier.BlockUpdate(message, 0, message.Length);
-            
-            return verifier.VerifySignature(signature);
-        }
-        catch
-        {
-            return false;
-        }
+        return Ed25519.Verify(signature, 0, edPublicKey, 0, message, 0, message.Length);
     }
 
     /// <summary>

--- a/Meshtastic/Crypto/XEdDSASigning.cs
+++ b/Meshtastic/Crypto/XEdDSASigning.cs
@@ -42,9 +42,33 @@ public static class XEdDSASigning
         if (x25519PrivateKey.Length != 32)
             throw new ArgumentException("X25519 private key must be 32 bytes", nameof(x25519PrivateKey));
 
+        var ed25519PrivateKey = new byte[32];
+        Array.Copy(x25519PrivateKey, ed25519PrivateKey, ed25519PrivateKey.Length);
+        // Clamp X25519
+        ed25519PrivateKey[0] &= 0xF8;
+        ed25519PrivateKey[31] &= 0x7F;
+        ed25519PrivateKey[31] |= 0x40;
+
         var x25519PublicKey = PKIEncryption.GetPublicKeyFromPrivateKey(x25519PrivateKey);
-        var ed25519PublicKey = ConvertX25519PublicKeyToEd25519(x25519PublicKey);
-        return (x25519PrivateKey, ed25519PublicKey);
+        var ed25519PublicKey = ConvertX25519PublicKeyToEd25519(x25519PublicKey, forcePositive: false);
+
+        // If resulting public key is positive, return as-is
+        if ((ed25519PublicKey[31] & 0x80) == 0) return (x25519PrivateKey, ed25519PublicKey);
+
+        // Ed25519 Group Order
+        var L = new BigInteger("7237005577332262213973186563042994240857116359379907606001950938285454250989");
+
+        // Negate private key
+        var privateKeyScalar = new BigInteger(ed25519PrivateKey.Reverse().ToArray());
+        var negatedPrivateKeyScalar = L.Subtract(privateKeyScalar);
+        var negatedPrivateKeyBytes = negatedPrivateKeyScalar.ToByteArrayUnsigned();
+        byte[] negatedPrivateKey = new byte[32];
+        Array.Copy(negatedPrivateKeyBytes, 0, negatedPrivateKey, 0, negatedPrivateKeyBytes.Length);
+
+        // Recompute public key from negated privated key
+        var negatedPublicKey = ConvertX25519PublicKeyToEd25519(negatedPrivateKey);
+
+        return (negatedPrivateKey, negatedPublicKey);
     }
 
     /// <summary>
@@ -52,7 +76,7 @@ public static class XEdDSASigning
     /// </summary>
     /// <param name="x25519PublicKey">32-byte X25519 public key</param>
     /// <returns>32-byte Ed25519 public key</returns>
-    public static byte[] ConvertX25519PublicKeyToEd25519(byte[] x25519PublicKey)
+    public static byte[] ConvertX25519PublicKeyToEd25519(byte[] x25519PublicKey, bool forcePositive = false)
     {
         if (x25519PublicKey.Length != 32)
             throw new ArgumentException("X25519 public key must be 32 bytes", nameof(x25519PublicKey));
@@ -91,7 +115,7 @@ public static class XEdDSASigning
         // If yBytes is shorter than 32 bytes, the rest is already zero
 
         // Set the sign bit to 0 (positive x)
-        edPublicKeyResult[31] &= 0x7F;
+        if (forcePositive) edPublicKeyResult[31] &= 0x7F;
         return edPublicKeyResult;
     }
 

--- a/Meshtastic/Crypto/XEdDSASigning.cs
+++ b/Meshtastic/Crypto/XEdDSASigning.cs
@@ -34,6 +34,53 @@ public static class XEdDSASigning
         return (privateKey, publicKey);
     }
 
+    /*
+     * Reflected private methods from BouncyCastle's Org.BouncyCastle.Math.EC.Rfc8032.Ed25519 used directly,
+     * because proper public methods differ in implementation details from those in Meshtastic firmware.
+     * Using those methods seems less wrong than to re-implement them here.
+     */
+    private static Action<byte[], byte[], int>? ed25519_ScalarMultBaseEncoded;
+    private static Action<IDigest, byte[], byte[], byte[], int, byte[]?, byte, byte[], int, int, byte[], int>? ed25519_ImplSign;
+
+    private static void Ed25519_ScalarMultBaseEncoded(byte[] k, byte[] r, int rOff)
+    {
+        if (ed25519_ScalarMultBaseEncoded == null)
+        {
+            var method = typeof(Ed25519).GetMethod("ScalarMultBaseEncoded", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static, [typeof(byte[]), typeof(byte[]), typeof(int)]);
+            if (method == null) throw new InvalidOperationException("Reflected private method \"ScalarMultBaseEncoded\" in \"Org.BouncyCastle.Math.EC.Rfc8032.Ed25519\" not found.");
+            ed25519_ScalarMultBaseEncoded = (Action<byte[], byte[], int>)method.CreateDelegate(typeof(Action<byte[], byte[], int>));
+        }
+
+        ed25519_ScalarMultBaseEncoded(k, r, rOff);
+    }
+
+    private static void Ed25519_ImplSign(IDigest d, byte[] h, byte[] s, byte[] pk, int pkOff, byte[]? ctx, byte phflag, byte[] m, int mOff, int mLen, byte[] sig, int sigOff)
+    {
+        if (ed25519_ImplSign == null)
+        {
+            var method = typeof(Ed25519)
+            .GetMethod("ImplSign", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static,
+                [
+                    typeof(IDigest),
+                    typeof(byte[]),
+                    typeof(byte[]),
+                    typeof(byte[]),
+                    typeof(int),
+                    typeof(byte[]),
+                    typeof(byte),
+                    typeof(byte[]),
+                    typeof(int),
+                    typeof(int),
+                    typeof(byte[]),
+                    typeof(int)
+                ]);
+            if (method == null) throw new InvalidOperationException("Reflected private method \"ImplSign\" in \"Org.BouncyCastle.Math.EC.Rfc8032.Ed25519\" not found.");
+            ed25519_ImplSign = (Action<IDigest, byte[], byte[], byte[], int, byte[]?, byte, byte[], int, int, byte[], int>)method.CreateDelegate(typeof(Action<IDigest, byte[], byte[], byte[], int, byte[], byte, byte[], int, int, byte[], int>));
+        }
+
+        ed25519_ImplSign(d, h, s, pk, pkOff, ctx, phflag, m, mOff, mLen, sig, sigOff);
+    }
+
     private static byte[] GeneratePublicKeyFromPrivateKey(byte[] ed25519PrivateKey)
     {
         /*
@@ -50,9 +97,7 @@ public static class XEdDSASigning
          */
 
         var ed25519PublicKey = new byte[32];
-        typeof(Org.BouncyCastle.Math.EC.Rfc8032.Ed25519)
-            .GetMethod("ScalarMultBaseEncoded", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static, [typeof(byte[]), typeof(byte[]), typeof(int)])!
-            .Invoke(null, [ed25519PrivateKey, ed25519PublicKey, 0]);
+        Ed25519_ScalarMultBaseEncoded(ed25519PrivateKey, ed25519PublicKey, 0);
         return ed25519PublicKey;
     }
 
@@ -214,35 +259,7 @@ public static class XEdDSASigning
         digest.BlockUpdate(edPrivateKey, 0, 32);
         digest.DoFinal(h, 0);
 
-        typeof(Ed25519)
-            .GetMethod("ImplSign", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static, 
-            [
-                typeof(IDigest),
-                typeof(byte[]),
-                typeof(byte[]),
-                typeof(byte[]),
-                typeof(int),
-                typeof(byte[]),
-                typeof(byte),
-                typeof(byte[]),
-                typeof(int),
-                typeof(int),
-                typeof(byte[]),
-                typeof(int)
-            ])!
-            .Invoke(null, [
-                /* IDigest d */ digest,
-                /* byte[] h */ h,
-                /* byte[] s */ edPrivateKey /* original argument: s, scalar computed from h */,
-                /* byte[] pk */ edPublicKey,
-                /* int pkOff */ 0,
-                /* byte[] ctx */ null,
-                /* byte phflag */ (byte)0,
-                /* byte[] */ message,
-                /* int mOff*/ 0,
-                /* int mLen */ message.Length,
-                /* byte[] sig */ signature,
-                /* int sigOff */ 0]);
+        Ed25519_ImplSign(digest, h, edPrivateKey /* original argument: s, scalar computed from h */, edPublicKey, 0, null, 0, message, 0, message.Length, signature, 0);
 
         return signature;
     }

--- a/Meshtastic/Crypto/XEdDSASigning.cs
+++ b/Meshtastic/Crypto/XEdDSASigning.cs
@@ -83,7 +83,7 @@ public static class XEdDSASigning
 
         // Negate private key
         var privateKeyScalar = new BigInteger(1, ed25519PrivateKey.Reverse().ToArray());
-        var negatedPrivateKeyScalar = L.Subtract(privateKeyScalar);
+        var negatedPrivateKeyScalar = L.Subtract(privateKeyScalar.Mod(L));
         var negatedPrivateKeyBytes = negatedPrivateKeyScalar.ToByteArrayUnsigned();
         byte[] negatedPrivateKey = new byte[32];
         for (int i = 0; i < negatedPrivateKeyBytes.Length && i < 32; i++)

--- a/Meshtastic/Data/MessageFactories/NodeInfoMessageFactory.cs
+++ b/Meshtastic/Data/MessageFactories/NodeInfoMessageFactory.cs
@@ -17,13 +17,11 @@ public static class NodeInfoMessageFactory
     /// <param name="deviceStateContainer">Device state containing configuration</param>
     /// <param name="user">User information to broadcast</param>
     /// <param name="signPacket">Whether to sign the packet with XEdDSA</param>
-    /// <param name="useShortHash">Use SHA-256 instead of SHA-512 for signatures</param>
     /// <returns>MeshPacket containing the NodeInfo</returns>
     public static MeshPacket CreateNodeInfoMessage(
         DeviceStateContainer deviceStateContainer,
         User user,
-        bool signPacket = false,
-        bool useShortHash = true)
+        bool signPacket = false)
     {
         if (deviceStateContainer == null)
             throw new ArgumentNullException(nameof(deviceStateContainer));
@@ -55,7 +53,7 @@ public static class NodeInfoMessageFactory
         {
             try
             {
-                AddXEdDSASignature(meshPacket, deviceStateContainer, useShortHash);
+                AddXEdDSASignature(meshPacket, deviceStateContainer);
             }
             catch (Exception)
             {
@@ -106,12 +104,10 @@ public static class NodeInfoMessageFactory
     /// </summary>
     /// <param name="meshPacket">Received mesh packet</param>
     /// <param name="senderPublicKey">Public key of the sender</param>
-    /// <param name="useShortHash">Use SHA-256 instead of SHA-512</param>
     /// <returns>True if signature is valid</returns>
     public static bool VerifyNodeInfoSignature(
         MeshPacket meshPacket,
-        byte[] senderPublicKey,
-        bool useShortHash = true)
+        byte[] senderPublicKey)
     {
         if (meshPacket?.Decoded?.Payload == null)
             return false;
@@ -127,7 +123,7 @@ public static class NodeInfoMessageFactory
             // For now, we'll demonstrate the verification process
             var mockSignature = new byte[64]; // This would come from the packet
 
-            return XEdDSASigning.Verify(payload, mockSignature, senderPublicKey, useShortHash);
+            return XEdDSASigning.Verify(payload, mockSignature, senderPublicKey);
         }
         catch
         {
@@ -142,7 +138,7 @@ public static class NodeInfoMessageFactory
         return deviceStateContainer.LocalConfig?.Security?.PublicKey != null;
     }
 
-    private static void AddXEdDSASignature(MeshPacket meshPacket, DeviceStateContainer deviceStateContainer, bool useShortHash)
+    private static void AddXEdDSASignature(MeshPacket meshPacket, DeviceStateContainer deviceStateContainer)
     {
         if (meshPacket.Decoded?.Payload == null)
             return;
@@ -157,7 +153,7 @@ public static class NodeInfoMessageFactory
 
         // Sign the payload
         var payload = meshPacket.Decoded.Payload.ToByteArray();
-        var signature = XEdDSASigning.Sign(payload, edPrivateKey, edPublicKey, useShortHash);
+        var signature = XEdDSASigning.Sign(payload, edPrivateKey, edPublicKey);
 
         // Note: In the actual implementation, we would add the signature to the packet
         // For now, we'll store it in a custom field or metadata
@@ -200,14 +196,12 @@ public static class NodeInfoMessageFactory
         var signedSha256Packet = CreateNodeInfoMessage(
             deviceStateContainer: testDeviceState,
             user: user,
-            signPacket: true,
-            useShortHash: true);
+            signPacket: true);
 
         var signedSha512Packet = CreateNodeInfoMessage(
             deviceStateContainer: testDeviceState,
             user: user,
-            signPacket: true,
-            useShortHash: false);
+            signPacket: true);
 
         // Since signing currently fails silently due to no private key,
         // we'll simulate the signature overhead by creating packets with mock signatures


### PR DESCRIPTION
Related to #130 - suggestion for changes to `XEdDSASigning` to make it work with actual signatures as generated by latest firmware. Verified manually via packet dumps from MQTT. This could use some actual test cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Updated packet and cryptographic signing/verification to consistently use raw signing buffer/message bytes, removing the alternate “short hash” option.
  * Public signing APIs updated: `Sign`/`Verify`/`VerifyWithX25519Key` no longer accept the hashing-mode parameter; `ConvertX25519PublicKeyToEd25519` now supports an optional `forcePositive` flag.

* **Bug Fixes**
  * NodeInfo packet signing and verification now follow the same streamlined signing process end-to-end, with additional argument validation during verification.

* **Tests**
  * Expanded X25519→Ed25519 conversion coverage with dedicated positive/negative sign-bit cases; updated signing/verification test expectations and removed the hash-mode parameterized test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->